### PR TITLE
Use Publish CommandLine to display a nice error.

### DIFF
--- a/Sources/ReadingTimePublishPlugin/CommandLine+Output.swift
+++ b/Sources/ReadingTimePublishPlugin/CommandLine+Output.swift
@@ -1,0 +1,47 @@
+/**
+* CommandLine extension taken from Publish itself.
+* https://github.com/JohnSundell/Publish/blob/master/Sources/Publish/Internal/CommandLine%2BOutput.swift
+*/
+
+import Foundation
+
+var output: (String, OutputKind) -> Void = { (string, kind) in
+    var string = string + "\n"
+
+    if let emoji = kind.emoji {
+        string = "\(emoji) \(string)"
+    }
+
+    fputs(string, kind.target)
+}
+
+enum OutputKind {
+    case info
+    case warning
+    case error
+    case success
+}
+   
+private extension OutputKind {
+    var emoji: Character? {
+        switch self {
+        case .info:
+            return nil
+        case .warning:
+            return "⚠️"
+        case .error:
+            return "❌"
+        case .success:
+            return "✅"
+        }
+    }
+
+    var target: UnsafeMutablePointer<FILE> {
+        switch self {
+        case .info, .warning, .success:
+            return stdout
+        case .error:
+            return stdout
+        }
+    }
+}

--- a/Sources/ReadingTimePublishPlugin/ReadingTime.swift
+++ b/Sources/ReadingTimePublishPlugin/ReadingTime.swift
@@ -25,9 +25,9 @@ extension Plugin {
 public extension Item {
     var readingTime: ReadingTimeMetadata {
         guard let metadata = data[self] else {
-            CommandLine.output(
+            output(
                 #"Item "\#(self.title)" doesn't have ReadingTimeMetadata. Check that the ReadingTime plugin is installed after the creation of this item."#,
-                as: .error
+                .error
             )
             return ReadingTimeMetadata(minutes: 0, words: 0)
         }

--- a/Sources/ReadingTimePublishPlugin/ReadingTime.swift
+++ b/Sources/ReadingTimePublishPlugin/ReadingTime.swift
@@ -25,7 +25,11 @@ extension Plugin {
 public extension Item {
     var readingTime: ReadingTimeMetadata {
         guard let metadata = data[self] else {
-            fatalError()
+            CommandLine.output(
+                #"Item "\#(self.title)" doesn't have ReadingTimeMetadata. Check that the ReadingTime plugin is installed after the creation of this item."#,
+                as: .error
+            )
+            return ReadingTimeMetadata(minutes: 0, words: 0)
         }
         return metadata
     }

--- a/Tests/ReadingTimePublishPluginTests/ConsoleOutputTests.swift
+++ b/Tests/ReadingTimePublishPluginTests/ConsoleOutputTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import ReadingTimePublishPlugin
+import Publish
+import Plot
+
+final class ConsoleOutputTests: XCTestCase {
+    
+    var capturedOutput: String?
+    
+    override func setUp() {
+        super.setUp()
+        
+        capturedOutput = nil
+        
+        output = { string, kind in
+            self.capturedOutput = string
+        }
+    }
+    
+    func testItemWithoutMetadata() {
+        let item: Item<Web> = .mock
+        
+        let metadata = item.readingTime
+        XCTAssertEqual(metadata.words, 0)
+        XCTAssertEqual(metadata.minutes, 0)
+        XCTAssertEqual(
+            capturedOutput,
+            #"Item "Fake" doesn't have ReadingTimeMetadata. Check that the ReadingTime plugin is installed after the creation of this item."#
+        )
+    }
+    
+}
+
+private extension Item where Site == Web {
+    static let mock = Item<Web>(
+        path: Path.init("/none"),
+        sectionID: Web.SectionID.test,
+        metadata: Web.ItemMetadata(),
+        tags: [],
+        content: Content(title: "Fake", description: "None", body: .init(html: ""), date: Date(), lastModified: Date(), imagePath: nil, audio: nil, video: nil)
+    )
+}
+
+private struct Web: Website {
+    var url: URL
+    
+    var name: String
+    
+    var description: String
+    
+    var language: Language
+    
+    var imagePath: Path?
+    
+    enum SectionID: String, WebsiteSectionID {
+        case test
+    }
+    
+    struct ItemMetadata: WebsiteItemMetadata {
+    }
+}

--- a/Tests/ReadingTimePublishPluginTests/ReadingTimeTests.swift
+++ b/Tests/ReadingTimePublishPluginTests/ReadingTimeTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import ReadingTimePublishPlugin
 
-final class PublishReadingTimeTests: XCTestCase {
+final class ReadingTimeTests: XCTestCase {
     
     func testShortText() {
         Assert(
@@ -98,10 +98,6 @@ final class PublishReadingTimeTests: XCTestCase {
             minutes: 0.025
         )
     }
-
-    static var allTests = [
-        ("testShortText", testShortText),
-    ]
 }
 
 func Assert(

--- a/Tests/ReadingTimePublishPluginTests/XCTestManifests.swift
+++ b/Tests/ReadingTimePublishPluginTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(ReadingTimePublishPluginTests.allTests),
-    ]
-}
-#endif


### PR DESCRIPTION
**This needs changes on Publish to make the CommandLine extension public**

The plugin expects to be run after all Items are added to a Site. But in case this is not the case it now shows a nice error when the reading metadata is accessed.

```
Publishing Multiverse (6 steps)
[1/6] Copy 'Resources' files
[2/6] Add Markdown files from 'Content' folder
[3/6] Sort items
[4/6] Generate HTML
❌ Item "This should be read in six minutes" doesn't have ReadingTimeMetadata. Check that the ReadingTime plugin is installed after the creation of this item.
```