### PR TITLE
Publish 0.9.0 Compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,12 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 
 let package = Package(
     name: "ReadingTimePublishPlugin",
+    platforms: [
+        .macOS(.v12)
+    ],
     products: [
         .library(
             name: "ReadingTimePublishPlugin",


### PR DESCRIPTION
In order to use Publish 0.9.0 the swift version and os need to be updated accordingly.